### PR TITLE
fix building old gcc with new gcc by using -std=gnu89

### DIFF
--- a/tools/install_gcc_539
+++ b/tools/install_gcc_539
@@ -16,6 +16,8 @@ if [ "`which gmake`" != "" ]; then
         MAKE=gmake
 fi
 
+export CFLAGS="-O2 -pipe -std=gnu89"
+
 while read a
 do
   echo "$a"

--- a/tools/install_gcc_539_thumb
+++ b/tools/install_gcc_539_thumb
@@ -16,6 +16,8 @@ if [ "`which gmake`" != "" ]; then
         MAKE=gmake
 fi
 
+export CFLAGS="-O2 -pipe -std=gnu89"
+
 while read a
 do
   echo "$a"


### PR DESCRIPTION
I've been building some of these on arch. Not sure if this is everything thats needed for the gcc-539 ... 
(i needed to build an older bison and set that in the path for something, but cant remember if it was for this.)